### PR TITLE
Added commands /dm /joindate /uptime /resetnick /setnick /spoiler

### DIFF
--- a/commands/general/dm.js
+++ b/commands/general/dm.js
@@ -1,0 +1,30 @@
+const { SlashCommandBuilder } = require('discord.js');
+const { MessageFlags } = require('discord.js');
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('dm')
+    .setDescription('Send yourself a private message')
+    .addStringOption(option =>
+      option.setName('message')
+        .setDescription('The message you want to DM yourself')
+        .setRequired(true)
+    ),
+  async execute(interaction) {
+    const message = interaction.options.getString('message');
+
+    try {
+      await interaction.user.send(message);
+      await interaction.reply({
+        content: '📬 Message sent to your DMs!',
+        flags: MessageFlags.Ephemeral
+      });
+    } catch (error) {
+      console.error(error);
+      await interaction.reply({
+        content: '❌ I couldn’t send you a DM. Do you have DMs enabled?',
+        flags: MessageFlags.Ephemeral
+      });
+    }
+  },
+};

--- a/commands/general/joindate.js
+++ b/commands/general/joindate.js
@@ -1,0 +1,31 @@
+const { SlashCommandBuilder } = require('discord.js');
+const { time } = require('@discordjs/builders');
+const { MessageFlags } = require('discord.js');
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('joindate')
+    .setDescription("Check when you or someone else joined this server")
+    .addUserOption(option =>
+      option
+        .setName('user')
+        .setDescription('The user to check (optional)')
+        .setRequired(false)
+    ),
+  async execute(interaction) {
+    const user = interaction.options.getUser('user') || interaction.user;
+    const member = await interaction.guild.members.fetch(user.id);
+
+    if (!member) {
+      return interaction.reply({
+        content: '❌ Could not find that user in this server.',
+        flags: MessageFlags.Ephemeral
+      });
+    }
+
+    const joinedAt = member.joinedAt;
+    await interaction.reply(
+      `📅 **${user.username}** joined this server on **${time(joinedAt, 'F')}**`
+    );
+  }
+};

--- a/commands/general/resetnick.js
+++ b/commands/general/resetnick.js
@@ -1,0 +1,23 @@
+const { SlashCommandBuilder } = require('discord.js');
+const { MessageFlags } = require('discord.js');
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('resetnick')
+    .setDescription('Reset your nickname to your original username'),
+  async execute(interaction) {
+    try {
+      await interaction.member.setNickname(null);
+      await interaction.reply({
+        content: '🔄 Your nickname has been reset!',
+        flags: MessageFlags.Ephemeral
+      });
+    } catch (error) {
+      console.error(error);
+      await interaction.reply({
+        content: '❌ I couldn’t reset your nickname. Do I have permission?',
+        flags: MessageFlags.Ephemeral
+      });
+    }
+  },
+};

--- a/commands/general/setnick.js
+++ b/commands/general/setnick.js
@@ -1,0 +1,32 @@
+const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
+const { MessageFlags } = require('discord.js');
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('setnick')
+    .setDescription('Change your display name (nickname) in the server')
+    .addStringOption(option =>
+      option.setName('nickname')
+        .setDescription('The new nickname you want')
+        .setRequired(true)
+    ),
+  async execute(interaction) {
+    const newNickname = interaction.options.getString('nickname');
+
+    try {
+      // Attempt to change the nickname of the user
+      await interaction.member.setNickname(newNickname);
+
+      await interaction.reply({
+        content: `✅ Nickname changed to **${newNickname}**!`,
+        flags: MessageFlags.Ephemeral
+      });
+    } catch (error) {
+      console.error(error);
+      await interaction.reply({
+        content: '❌ I was unable to change your nickname. Do I have permission?',
+        flags: MessageFlags.Ephemeral
+      });
+    }
+  }
+};

--- a/commands/general/spoiler.js
+++ b/commands/general/spoiler.js
@@ -1,0 +1,16 @@
+const { SlashCommandBuilder } = require('discord.js');
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('spoiler')
+    .setDescription('Hide your message as a spoiler')
+    .addStringOption(option =>
+      option.setName('text')
+        .setDescription('The text to mark as spoiler')
+        .setRequired(true)
+    ),
+  async execute(interaction) {
+    const text = interaction.options.getString('text');
+    await interaction.reply(`||${text}||`);
+  },
+};

--- a/commands/general/uptime.js
+++ b/commands/general/uptime.js
@@ -1,0 +1,23 @@
+const { SlashCommandBuilder } = require('discord.js');
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('uptime')
+    .setDescription('🕒 Shows how long the bot has been online'),
+
+  async execute(interaction) {
+    const totalSeconds = Math.floor(process.uptime());
+    const days = Math.floor(totalSeconds / (3600 * 24));
+    const hours = Math.floor((totalSeconds % (3600 * 24)) / 3600);
+    const minutes = Math.floor((totalSeconds % 3600) / 60);
+    const seconds = totalSeconds % 60;
+
+    let uptimeString = '';
+    if (days > 0) uptimeString += `${days}d `;
+    if (hours > 0 || uptimeString) uptimeString += `${hours}h `;
+    if (minutes > 0 || uptimeString) uptimeString += `${minutes}m `;
+    uptimeString += `${seconds}s`;
+
+    await interaction.reply(`✅ **Bot Uptime:** ${uptimeString}`);
+  }
+};


### PR DESCRIPTION
I added 6 new commands. Here is the list of commands and their use cases along with the syntax :

>```/uptime```
> - Shows how long the bot has been up. (This was the original task assigened to me.)

> ```/dm <message>```
> - Allows users to dm themselves with a message they input.

>```/joindate <@mention>```
> - Shows when someone has joined the server. Works on everyone in the server.

>```/setnick <new-name>```
> - Lets users change their username. Super useful for lazy people who dont like to open settings to change their server profile.

>```/resetnick```
> - Resets the name of the user to default.

>```/spoiler <message>```
> - Takes a message from the user and adds || ... || to it.