### PR TITLE
added /inspire command

### DIFF
--- a/commands/fun/inspire.js
+++ b/commands/fun/inspire.js
@@ -1,0 +1,40 @@
+const { SlashCommandBuilder, EmbedBuilder } = require("discord.js");
+const axios = require("axios");
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName("inspire")
+    .setDescription("💡 Get a random motivational quote to brighten your day"),
+  cooldown: 3,
+
+  async execute(interaction, client) {
+    await interaction.deferReply(); // Let Discord know we're working
+
+    try {
+      // Fetch a random motivational quote from ZenQuotes API
+      const res = await axios.get("https://zenquotes.io/api/random");
+      const quote = res.data[0].q;
+      const author = res.data[0].a;
+
+      // Create the embed message
+      const embed = new EmbedBuilder()
+        .setColor(client?.colors?.success || "#00FFAA")
+        .setTitle("🌟 Inspiration of the Moment")
+        .setDescription(`*"${quote}"*\n\n— **${author}**`)
+        .setFooter({
+          text: `Requested by ${interaction.user.tag}`,
+          iconURL: interaction.user.displayAvatarURL(),
+        })
+        .setTimestamp();
+
+      // Send the embed response
+      await interaction.editReply({ embeds: [embed] });
+
+    } catch (error) {
+      console.error("❌ Failed to fetch quote:", error.message);
+      await interaction.editReply({
+        content: "❌ Couldn't fetch a quote right now. Please try again later.",
+      });
+    }
+  },
+};

--- a/package.json
+++ b/package.json
@@ -34,13 +34,14 @@
   },
   "dependencies": {
     "@google/generative-ai": "^0.7.1",
-    "axios": "^1.6.2",
+    "axios": "^1.11.0",
     "discord.js": "^14.14.1",
     "dotenv": "^16.3.1",
     "express": "^5.1.0",
     "mongoose": "^8.0.3",
     "ms": "^2.1.3",
-    "node-cron": "^3.0.3"
+    "node-cron": "^3.0.3",
+    "node-fetch": "^2.7.0"
   },
   "devDependencies": {
     "nodemon": "^3.0.2"


### PR DESCRIPTION
Closes #5

### ✨ Added `/inspire` Command

This PR introduces a new slash command `/inspire` that fetches a random motivational quote using the [ZenQuotes API](https://zenquotes.io/). It displays the quote in a styled embed along with the author's name.

### ✅ Features
- Uses `axios` to fetch from a free public API (`https://zenquotes.io/api/random`)
- Displays quote and author in an embed
- Handles API failures gracefully with error messages

### 🧪 Screenshot (example output)
<img width="707" height="392" alt="inspire" src="https://github.com/user-attachments/assets/ad55f219-037b-4d71-b1a8-0cb0dc09079e" />



